### PR TITLE
Upgrade LKML and store content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.0.3
-  * Upgrade lkml and store content [#3](https://github.com/singer-io/tap-lookml/pull/3)
+  * Upgrade lkml and store content [#5](https://github.com/singer-io/tap-lookml/pull/5)
 
 ## 0.0.2
   * Replication keys now receive automatic inclusion metadata [#2](https://github.com/singer-io/tap-lookml/pull/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.3
+  * Upgrade lkml and store content [#3](https://github.com/singer-io/tap-lookml/pull/3)
+
 ## 0.0.2
   * Replication keys now receive automatic inclusion metadata [#2](https://github.com/singer-io/tap-lookml/pull/2)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='tap-lookml',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_lookml'],
       install_requires=[
-          'lkml==0.2.1',
+          'lkml==1.1.2',
           'backoff==1.8.0',
           'requests==2.22.0',
           'singer-python==5.8.1'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-lookml',
-      version='0.0.2',
+      version='0.0.3',
       description='Singer.io tap for extracting metadata from LookML files with the GitHub API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_lookml/schemas/models.json
+++ b/tap_lookml/schemas/models.json
@@ -137,6 +137,9 @@
             },
             "type": ["null", "array"]
           },
+          "extension": {
+            "type": ["null", "string"]
+          },
           "fields": {
             "items": {
               "type": ["null", "string"]

--- a/tap_lookml/schemas/models.json
+++ b/tap_lookml/schemas/models.json
@@ -137,9 +137,6 @@
             },
             "type": ["null", "array"]
           },
-          "extension": {
-            "type": ["null", "string"]
-          },
           "fields": {
             "items": {
               "type": ["null", "string"]

--- a/tap_lookml/sync.py
+++ b/tap_lookml/sync.py
@@ -183,6 +183,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                 file_data.pop('content', None)
                 file_data['git_owner'] = git_owner
                 file_data['git_repository'] = git_repository
+                file_data['content'] = content_dict
                 # LOGGER.info('file_data: {}'.format(file_data)) # TESTING ONLY - COMMENT OUT
                 file_records.append(file_data)
 


### PR DESCRIPTION
1. upgrading the LKML package to ensure it can detect newer LookML features (including creating filters as { instead of [)
2. storing content which previously was not showing up for view_files

It's hard for me to show the QA since I don't want to reveal too much about our repo, but here is the state.json that ran and has content in it:
<img width="197" alt="Screen Shot 2022-01-29 at 10 17 27 PM" src="https://user-images.githubusercontent.com/46604073/151685350-170267bd-c536-46a8-911d-ea8d49c0d959.png">

